### PR TITLE
Feature/authentication

### DIFF
--- a/netfix/settings.py
+++ b/netfix/settings.py
@@ -135,3 +135,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 
 AUTH_USER_MODEL = 'users.User'
+
+LOGIN_URL = '/register/'
+
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+

--- a/netfix/urls.py
+++ b/netfix/urls.py
@@ -26,5 +26,6 @@ urlpatterns = [
     path('register/', include('users.urls')),
     path('customer/<slug:name>', v.customer_profile, name='customer_profile'),
     path('company/<slug:name>', v.company_profile, name='company_profile'),
-    path('logout/', LogoutView.as_view(next_page='/'), name='logout')
+    path('logout/', LogoutView.as_view(next_page='/'), name='logout'),
+    # path('login/', auth_views.LoginView.as_view(), name='login'),
 ]

--- a/services/templates/services/service_detail.html
+++ b/services/templates/services/service_detail.html
@@ -11,9 +11,10 @@
                         <span class="badge bg-primary me-2">
                             <i class="fas fa-tools me-1"></i> {{ service.field }}
                         </span>
-                        <span class="text-muted">
+                        <!-- <span class="text-muted">
                             <i class="fas fa-building me-1"></i> {{ service.company.user.username }}
-                        </span>
+                        </span> -->
+                        <p class="mb-2"> <b>by:</b> {{ service.company.user.username }}</p>
                     </div>
                     
                     <div class="row mb-3">

--- a/services/views.py
+++ b/services/views.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.db import models
 from django.urls import reverse_lazy
 from django.views.generic import CreateView
+from django.contrib.auth.mixins import LoginRequiredMixin
 
 # and import the ModelForm you want to use:
 from .forms import ServiceForm
@@ -311,10 +312,16 @@ def most_requested_services(request):
         'fields': fields,
         'search_query': search_query,
         'field_filter': field_filter
-    })
+    }) 
 
-class ServiceCreateView(CreateView):
+# @login_required
+class ServiceCreateView(LoginRequiredMixin,CreateView):
     model = Service
     form_class = ServiceForm
     template_name = 'services/service_form.html'
     success_url = reverse_lazy('service_list')
+
+    # where to send users who aren’t logged in:
+    login_url = reverse_lazy('login_user')
+    # query-string param that holds “where to go next” (defaults to "next")
+    redirect_field_name = 'next'

--- a/users/templates/users/company_profile.html
+++ b/users/templates/users/company_profile.html
@@ -10,6 +10,7 @@
                     <p class="text-muted">{{ company.user.email }}</p>
                     <p><strong>Field:</strong> {{ company.field }}</p>
                     <p><strong>Rating:</strong> {{ company.rating }}</p>
+                    <hr>
                         <!-- {% for i in "12345"|make_list %}
                             {% if forloop.counter <= company.rating %}
                                 <i class="fas fa-star text-warning"></i>
@@ -35,6 +36,7 @@
                     <div class="row">
                         {% for service in services %}
                         <div class="col-md-6 mb-4">
+                            <hr>
                             <div class="card h-100">
                                 {% if service.image %}
                                 <img src="{{ service.image.url }}" class="card-img-top" alt="{{ service.name }}">

--- a/users/templates/users/company_profile.html
+++ b/users/templates/users/company_profile.html
@@ -9,15 +9,15 @@
                     <h3 class="card-title">{{ company.user.username }}</h3>
                     <p class="text-muted">{{ company.user.email }}</p>
                     <p><strong>Field:</strong> {{ company.field }}</p>
-                    <p><strong>Rating:</strong> 
-                        {% for i in "12345"|make_list %}
+                    <p><strong>Rating:</strong> {{ company.rating }}</p>
+                        <!-- {% for i in "12345"|make_list %}
                             {% if forloop.counter <= company.rating %}
                                 <i class="fas fa-star text-warning"></i>
                             {% else %}
                                 <i class="far fa-star text-warning"></i>
                             {% endif %}
                         {% endfor %}
-                    </p>
+                    </p> -->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Enforce Login for Service Creation & Minor UI Adjustments

### Summary of Changes:

1.Access Control Enhancement 
- Replaced the old ServiceCreateView with LoginRequiredMixin to restrict service creation to authenticated users only.
- Set a custom login_url ('login_user') and redirect_field_name for unauthenticated access handling.

2.Template Cleanups
- Commented out the raw star rating loop in company_profile.html and replaced it with a simplified numeric display for readability.
- Cleaned up service_detail.html by replacing a commented username span with a clearer line: by: {{ service.company.user.username }}.

3.URL & Auth Config Updates
- Set LOGIN_URL to /register/ in settings.py to redirect unauthenticated users appropriately.
- Minor update to netfix/urls.py (commented out the unused login path for now).

These changes improve the user experience, enforce authentication where necessary and enhance template readability.